### PR TITLE
Implement RTC support for GBA games

### DIFF
--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -1276,17 +1276,9 @@ static void _doDeferredSetup(void) {
 	// Here's that workaround, but really the API needs to be thrown out and rewritten.
 	struct VFile* save = VFileFromMemory(savedata, GBA_SIZE_FLASH1M);
 
-  /* need to defer resetting the core on start so drivers are initialized */
-  core->reset(core);
+    /* need to defer resetting the core on start so drivers are initialized */
+    core->reset(core);
 	_setupMaps(core);
-
-#ifdef M_CORE_GBA
-  // Re-apply hardware overrides after reset to ensure consistent state
-  if (core->platform(core) == mPLATFORM_GBA) {
-    GBAOverrideApplyDefaults(core->board, NULL);
-  }
-#endif
-
 
 #if defined(COLOR_16_BIT) && defined(COLOR_5_6_5)
 	_loadPostProcessingSettings();
@@ -2026,7 +2018,7 @@ bool retro_load_game(const struct retro_game_info* game) {
 	}
 	mCoreInitConfig(core, NULL);
 	core->init(core);
-	
+
 #ifdef _3DS
 	outputBuffer = linearMemAlign(VIDEO_BUFF_SIZE, 0x80);
 #else

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -1299,7 +1299,7 @@ static void _doDeferredSetup(void) {
   if (core->platform(core) == mPLATFORM_GBA) {
     struct GBA* gba = (struct GBA*)core->board;
     if (gba->memory.hw.devices & HW_RTC) {
-      memcpy(gba->memory.hw.rtc.time, rtcExchangeBuffer.time, 7);
+      memcpy(gba->memory.hw.rtc.time, rtcExchangeBuffer.time, sizeof(rtcExchangeBuffer.time));
       gba->memory.hw.rtc.control = rtcExchangeBuffer.control;
       LOAD_64LE(gba->memory.hw.rtc.lastLatch, 0, &rtcExchangeBuffer.lastLatch);
 
@@ -1666,7 +1666,7 @@ void retro_run(void) {
     if (core->platform(core) == mPLATFORM_GBA) {
       struct GBA* gba = (struct GBA*)core->board;
       if (gba->memory.hw.devices & HW_RTC) {
-          memcpy(rtcExchangeBuffer.time, gba->memory.hw.rtc.time, 7);
+          memcpy(rtcExchangeBuffer.time, gba->memory.hw.rtc.time, sizeof(rtcExchangeBuffer.time));
           rtcExchangeBuffer.control = gba->memory.hw.rtc.control;
           STORE_64LE(gba->memory.hw.rtc.lastLatch, 0, &rtcExchangeBuffer.lastLatch);
       }

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -1281,19 +1281,12 @@ static void _doDeferredSetup(void) {
 	_setupMaps(core);
 
 #ifdef M_CORE_GBA
-  // Re-apply hardware overrides after reset to ensure consistent state
+  // Ensure hardware overrides are properly applied after reset
   if (core->platform(core) == mPLATFORM_GBA) {
     struct GBA* gba = (struct GBA*) core->board;
     if (gba) {
-      // Apply standard game overrides based on ROM ID
-      struct GBACartridgeOverride override = {0};
-      const struct GBACartridge* cart = (const struct GBACartridge*) gba->memory.rom;
-      if (cart) {
-        memcpy(override.id, &cart->id, 4);
-        if (GBAOverrideFind(NULL, &override)) {
-          GBAOverrideApply(gba, &override);
-        }
-      }
+      // Use the standard override detection and application
+      GBAOverrideApplyDefaults(gba, NULL);
     }
   }
 #endif
@@ -2310,7 +2303,7 @@ void* retro_get_memory_data(unsigned id) {
                 return gba->memory.hw.rtc.time;
             }
             
-            // If not, check if this game should have RTC according to our override database
+            // If not, check if this game should have RTC
             struct GBACartridgeOverride override = {0};
             const struct GBACartridge* cart = (const struct GBACartridge*) gba->memory.rom;
             if (cart) {
@@ -2402,7 +2395,7 @@ size_t retro_get_memory_size(unsigned id) {
                 return sizeof(gba->memory.hw.rtc.time);
             }
             
-            // If not, check if this game should have RTC according to our override database
+            // If not, check if this game should have RTC
             struct GBACartridgeOverride override = {0};
             const struct GBACartridge* cart = (const struct GBACartridge*) gba->memory.rom;
             if (cart) {

--- a/src/platform/libretro/libretro.c
+++ b/src/platform/libretro/libretro.c
@@ -2078,8 +2078,11 @@ bool retro_load_game(const struct retro_game_info* game) {
 	core->loadROM(core, rom);
 	
 #ifdef M_CORE_GBA
-	// Early initialization of hardware features based on game overrides
-	// This ensures features like RTC are available before deferred setup
+    // The key issue is that in libretro, the standard automatic override 
+    // application that would happen during reset is delayed because of 
+    // the deferred reset mechanism. This means there's a window between 
+    // ROM loading and the deferred reset where memory functions might 
+    // be called, but overrides haven't been applied yet.
 	if (core->platform(core) == mPLATFORM_GBA) {
 		GBAOverrideApplyDefaults(core->board, NULL);
 	}


### PR DESCRIPTION
This PR adds proper Real-Time Clock (RTC) support for GBA games through the libretro interface. It allows the
frontend to read and modify RTC data, which is critical for games like Pokémon Ruby/Sapphire/Emerald that use
time-based events.

The key issue is that in libretro, the standard automatic override application that would happen during reset is
delayed because of the deferred reset mechanism. This means there's a window between ROM loading and the deferred
reset where memory functions might be called, but overrides haven't been applied yet.

The standard core->loadROM(core, rom) doesn't apply overrides itself - it just loads the ROM data. The overrides
are normally applied during reset, but in libretro this reset is deferred.

That's why we need to manually apply overrides after ROM loading - it fills the gap between ROM loading and the
deferred reset where memory functions might be called.

1. Added a global rtcExchangeBuffer of type GBASavedataRTCBuffer to store RTC data
2. Modified retro_get_memory_data to return the buffer.
3. Modified retro_get_memory_size to return the size of the buffer.
4. Added code to the _doDeferredSetup function to copy data from the exchange buffer to the core's internal RTC
time structure
5. Added the _unBCD helper function to properly convert BCD time values

This implementation allows the frontend to:
1. Load RTC data via standard API methods.
2. Write updated RTC data back to save files.
3. Properly initialize the RTC state for games that require it.

<img width="1479" alt="Screenshot 2025-03-17 at 22 02 55" src="https://github.com/user-attachments/assets/d39c21f5-2d12-4b4a-b003-ef00d5c3753d" />

